### PR TITLE
Clean folder on build, don't recreate it

### DIFF
--- a/lib/build.es6
+++ b/lib/build.es6
@@ -129,7 +129,7 @@ var Build = {
 
   base: function(config, key, callback) {
     // Clean first.
-    rimraf(config[key].directory).then(function() {
+    rimraf(config[key].directory + '/*').then(function() {
       return mkdirp(config[key].directory);
     }).then(() => {
       this.process_all_targets(config, key, callback);


### PR DESCRIPTION
Based on our chat on Gitter, I changed the build process to make Truffle clean the inside of the build folder, not replace it. Worked for me.

From what @tcoulter shared, I realized having a `--keep` flag to toggle this behavior may be unnecessary if there's not an actual case where the folder itself needs to be actually recreated. 