### PR TITLE
Handle contract name not matching file name.

### DIFF
--- a/lib/contracts.es6
+++ b/lib/contracts.es6
@@ -154,6 +154,14 @@ var Contracts = {
               return;
             }
 
+            if(result[key] == null && Object.keys(result).length > 0) {
+              var contractName = Object.keys(result)[0];
+              if ((contractName.toUpperCase() == key.toUpperCase()) && (contractName != key)) {
+                callback(new Error("Could not get compiler results because contract name '" + contractName + "' is not identical to file name '" + key + "'."));
+                return;
+              }
+            }
+
             contract["binary"] = result[key].code;
             contract["abi"] = result[key].info.abiDefinition;
             finished(null, contract);


### PR DESCRIPTION
Added handling for cases where contract names are not case-sensitive identical to their corresponding file names, e.g. fooBar.sol contains a contract called 'FooBar'.

I made this change because I spent quite some time trying to get Truffle to deploy before I realized that the problem was my contract name and the file name in the contracts directory were not identical.

Let me know if you want me to make it more generic and handle all cases where the contact and files names do not match.