### PR TITLE
Closes #41: makes inject-contracts post-processor work in node env

### DIFF
--- a/lib/insert_contracts.js
+++ b/lib/insert_contracts.js
@@ -30,5 +30,13 @@ var __provisioner = {
 // If we're in the browser, call the helpers using the global
 // (window) scope. If we're in node, export the helpers as a module.
 if (module != null) {
-  module.exports = __provisioner;
-}
+  var obj = {};
+  __provisioner.set_provider( obj );
+  __provisioner.provision_contracts( obj ); 
+ 
+  module.exports = {
+    web3,
+    contracts: obj 
+  };
+};
+

--- a/lib/processors/post/inject_contracts.es6
+++ b/lib/processors/post/inject_contracts.es6
@@ -17,7 +17,7 @@ module.exports = function(contents, file, config, process, callback) {
 
     var provisioner = provision.asString(config);
 
-    var result = provisioner + "; if( module == null ) { __provisioner.provision_contracts(window); };\n\n" + contents + "; if( module == null ) { __provisioner.set_provider(window); };"
+    var result = 'if( module != null ) { var Pudding = require("ether-pudding"); }' + provisioner + "; if( module == null ) { \n __provisioner.provision_contracts(window); };\n\n" + contents + "; if( module == null ) { __provisioner.set_provider(window); };"
 
     callback(null, result);
   } catch(e) {

--- a/lib/processors/post/inject_contracts.es6
+++ b/lib/processors/post/inject_contracts.es6
@@ -17,7 +17,7 @@ module.exports = function(contents, file, config, process, callback) {
 
     var provisioner = provision.asString(config);
 
-    var result = provisioner + "__provisioner.provision_contracts(window);\n\n" + contents + "; __provisioner.set_provider(window);"
+    var result = provisioner + "; if( module == null ) { __provisioner.provision_contracts(window); };\n\n" + contents + "; if( module == null ) { __provisioner.set_provider(window); };"
 
     callback(null, result);
   } catch(e) {

--- a/lib/processors/post/inject_contracts.es6
+++ b/lib/processors/post/inject_contracts.es6
@@ -17,7 +17,7 @@ module.exports = function(contents, file, config, process, callback) {
 
     var provisioner = provision.asString(config);
 
-    var result = 'if( module != null ) { var Pudding = require("ether-pudding"); }' + provisioner + "; if( module == null ) { \n __provisioner.provision_contracts(window); };\n\n" + contents + "; if( module == null ) { __provisioner.set_provider(window); };"
+    var result = 'if( module != null ) { var Pudding = require("ether-pudding"); var web3    = require("web3"); }' + provisioner + "; if( module == null ) { \n __provisioner.provision_contracts(window); };\n\n" + contents + "; if( module == null ) { __provisioner.set_provider(window); };"
 
     callback(null, result);
   } catch(e) {


### PR DESCRIPTION
This PR will work with node, still I don't think its a good solution: 
To set up a web3 provider, web3 has to be passed as an object or wrapped.