### PR TITLE
Testing improvments

### DIFF
--- a/lib/test.es6
+++ b/lib/test.es6
@@ -2,10 +2,8 @@ var Mocha = require("mocha");
 var chai = require("chai");
 var dir = require("node-dir");
 var path = require("path");
-var web3 = require("web3");
 var fs = require("fs");
 var temp = require("temp");
-var Promise = require("bluebird");
 
 var Contracts = require("./contracts");
 
@@ -52,7 +50,7 @@ var Test = {
 
         Pudding.setWeb3(web3);
         PuddingLoader.load(config.environments.current.directory, Pudding, global, function(err, contract_names) {
-          for (var name in contract_names) {
+          for (var name in config.contracts.classes) {
             var contract = global[name];
             var inst = contract.at(contract.deployed_address);
             Truffle.log_filters.push(inst.allEvents({fromBlock: 0, toBlock: 'latest'}, function(err, results) {

--- a/lib/test.es6
+++ b/lib/test.es6
@@ -171,7 +171,7 @@ var Test = {
         // instead of the original to avoid getting cached.
         files = files.map(function(f) {
           var src = fs.readFileSync(f);
-          f = temp.path({prefix: "truffle-", suffix: path.extname(f)})
+          f = temp.path({prefix: "truffle-", suffix: "-"+path.basename(f)})
           fs.writeFileSync(f, src);
           return f;
         });

--- a/lib/test.es6
+++ b/lib/test.es6
@@ -53,9 +53,7 @@ var Test = {
           for (var name in config.contracts.classes) {
             var contract = global[name];
             var inst = contract.at(contract.deployed_address);
-            Truffle.log_filters.push(inst.allEvents({fromBlock: 0, toBlock: 'latest'}, function(err, results) {
-              // no-op, don't worry abuot tracking events just now
-            }));
+            Truffle.log_filters.push(inst.allEvents({fromBlock: 0, toBlock: 'latest'}));
           }
           done();
         });

--- a/lib/test.es6
+++ b/lib/test.es6
@@ -5,6 +5,7 @@ var path = require("path");
 var web3 = require("web3");
 var fs = require("fs");
 var temp = require("temp");
+var Promise = require("bluebird");
 
 var Contracts = require("./contracts");
 
@@ -56,6 +57,7 @@ var Test = {
 
     global.Truffle = {
       redeploy: redeploy_contracts,
+      handle_errs: (done) => { Promise.onPossiblyUnhandledRejection(done); }
     };
 
     global.contract = function(name, opts, tests) {

--- a/lib/test.es6
+++ b/lib/test.es6
@@ -130,7 +130,14 @@ var Test = {
 
             var logs = [];
             Truffle.log_filters.forEach(function(filter) {
-              logs = logs.concat(filter.get());
+              try {
+                logs = logs.concat(filter.get());
+              } catch (e) {
+                if (e.message.match(/Invalid parameters/)) {
+                  // filter is invalid because the contract no longer exists
+                  filter.stopWatching();
+                }
+              }
             });
             logs.sort(function(a, b) {
               var ret = a.blockNumber - b.blockNumber;

--- a/lib/test.es6
+++ b/lib/test.es6
@@ -80,7 +80,11 @@ var Test = {
 
       log_filters: [],
 
-      redeploy: redeploy_contracts,
+      redeploy: function(recompile, done) {
+        return new Promise(function(resolve, reject) {
+          redeploy_contracts(recompile, resolve);
+        });
+      },
       handle_errs: (done) => { Promise.onPossiblyUnhandledRejection(done); },
 
       reset: function(cb) {

--- a/lib/test.es6
+++ b/lib/test.es6
@@ -119,6 +119,12 @@ var Test = {
           });
         });
 
+        after("clear all filters after each suite", function(done) {
+          Truffle.log_filters.forEach(function(f) { f.stopWatching(); });
+          Truffle.log_filters = [];
+          done();
+        });
+
         afterEach("check logs on failure", function(done) {
           if (this.currentTest.state == "failed") {
 

--- a/lib/test.es6
+++ b/lib/test.es6
@@ -36,11 +36,10 @@ var Test = {
 
     // Deploy all configured contracts to the chain without recompiling
     var redeploy_contracts = function(recompile, done) {
-      this.timeout(BEFORE_TIMEOUT);
+      this && this.timeout && this.timeout(BEFORE_TIMEOUT);
 
       Contracts.deploy(config, recompile, function(err) {
         if (err != null) {
-
           // Format our error messages so they print better with mocha.
           if (err instanceof ExtendableError) {
             err.formatForMocha();
@@ -53,6 +52,10 @@ var Test = {
         Pudding.setWeb3(web3);
         PuddingLoader.load(config.environments.current.directory, Pudding, global, done);
       });
+    };
+
+    global.Truffle = {
+      redeploy: redeploy_contracts,
     };
 
     global.contract = function(name, opts, tests) {

--- a/lib/test.es6
+++ b/lib/test.es6
@@ -113,8 +113,18 @@ var Test = {
       describe(`Contract: ${name}`, function() {
         this.timeout(TEST_TIMEOUT);
 
+        var _original_contracts = {};
+
         before("redeploy before each suite", function(done) {
           redeploy_contracts.call(this, true, function() {
+
+            // Store address that was first deployed, in case we redeploy
+            // from within a test
+            for (var name in config.contracts.classes) {
+              var contract = global[name];
+              _original_contracts[name] = contract.deployed_address;
+            }
+
             done();
           });
         });
@@ -122,6 +132,13 @@ var Test = {
         after("clear all filters after each suite", function(done) {
           Truffle.log_filters.forEach(function(f) { f.stopWatching(); });
           Truffle.log_filters = [];
+          done();
+        });
+
+        afterEach("restore contract address", function(done) {
+          for (var name in _original_contracts) {
+            global[name].deployed_address = _original_contracts[name];
+          }
           done();
         });
 

--- a/lib/test.es6
+++ b/lib/test.es6
@@ -168,6 +168,9 @@ var Test = {
               console.log("\n    Events emitted during test:");
               console.log(  "    ---------------------------");
               logs.forEach(function(log) {
+                if (!log.event) {
+                  return; // only want log events
+                }
                 if (log.event.toLowerCase() == "debug") {
                   console.log("[DEBUG]", log.args.msg);
                   return;

--- a/lib/test.es6
+++ b/lib/test.es6
@@ -115,6 +115,10 @@ var Test = {
 
         var _original_contracts = {};
 
+        before("reset evm before each suite", function(done) {
+          Truffle.reset(done);
+        });
+
         before("redeploy before each suite", function(done) {
           redeploy_contracts.call(this, true, function() {
 

--- a/package.json
+++ b/package.json
@@ -27,10 +27,10 @@
     "solc": "^0.1.5",
     "uglify-js": "^2.5.0",
     "web3": "0.14.0",
-    "yargs": "^3.27.0"
+    "yargs": "^3.27.0",
+    "temp": "^0.8.3"
   },
   "devDependencies": {
-    "temp": "*"
   },
   "bin": {
     "truffle": "./truffle.bash",

--- a/truffle.es6
+++ b/truffle.es6
@@ -332,8 +332,6 @@ registerTask('serve', "Serve app on http://localhost:8080 and rebuild changes as
 
 
 registerTask('watch:tests', "Watch filesystem for changes and rerun tests automatically", function(done) {
-  var needs_rebuild = true;
-
   watchr.watch({
     paths: [
       path.join(working_dir, "app"),
@@ -353,30 +351,24 @@ registerTask('watch:tests', "Watch filesystem for changes and rerun tests automa
       process.stdout.write("\u001b[2J\u001b[0;0H"); // clear screen
       var display_path = "./" + filePath.replace(working_dir, "");
       console.log(colors.cyan(`>> File ${display_path} changed.`));
-      needs_rebuild = true;
+      run_tests();
     },
     persistent: true,
     interval: 100, // use values from grunt-contrib-watch
     catchupDelay: 500
   });
 
-  var check_rebuild = function() {
-    if (needs_rebuild == true) {
-      needs_rebuild = false;
-      console.log("Running tests...");
+  var run_tests = function() {
+    console.log("Running tests...");
 
-      process.chdir(working_dir);
-      var config = Config.gather(truffle_dir, working_dir, argv, "test");
+    process.chdir(working_dir);
+    var config = Config.gather(truffle_dir, working_dir, argv, "test");
+    config.argv.quietDeploy = true; // Ensure we're quiet about deploys during tests
 
-      // Ensure we're quiet about deploys during tests.
-      config.argv.quietDeploy = true;
-
-      Test.run(config, function() { console.log("> test run complete; watching for changes..."); });
-    }
-    setTimeout(check_rebuild, 100);
+    Test.run(config, function() { console.log("> test run complete; watching for changes..."); });
   };
+  run_tests(); // run once immediately
 
-  setInterval(check_rebuild, 100);
 });
 
 

--- a/truffle.es6
+++ b/truffle.es6
@@ -332,17 +332,10 @@ registerTask('serve', "Serve app on http://localhost:8080 and rebuild changes as
 
 
 registerTask('watch:tests', "Watch filesystem for changes and rerun tests automatically", function(done) {
-  watchr.watch({
-    paths: [
-      path.join(working_dir, "app"),
-      path.join(working_dir, "config"),
-      path.join(working_dir, "contracts"),
-      path.join(working_dir, "test")
-    ],
-    next: function() {
-      console.log("Watching...")
-    },
-    listener: function(changeType, filePath, fileCurrentStat, filePreviousStat) {
+
+  gaze(["app/**/*", "config/**/*", "contracts/**/*", "test/**/*"], {cwd: working_dir, interval: 1000, debounceDelay: 500}, function() {
+    // On changed/added/deleted
+    this.on('all', function(event, filePath) {
       if (filePath.match(/\/config\/.*?\/contracts\.json$/)) {
         // ignore changes to /config/*/contracts.json since these changes every time
         // tests are run
@@ -352,11 +345,7 @@ registerTask('watch:tests', "Watch filesystem for changes and rerun tests automa
       var display_path = "./" + filePath.replace(working_dir, "");
       console.log(colors.cyan(`>> File ${display_path} changed.`));
       run_tests();
-    },
-    preferredMethods: ["watchFile", "watch"],
-    persistent: true,
-    interval: 100, // use values from grunt-contrib-watch
-    catchupDelay: 500
+    });
   });
 
   var run_tests = function() {

--- a/truffle.es6
+++ b/truffle.es6
@@ -353,6 +353,7 @@ registerTask('watch:tests', "Watch filesystem for changes and rerun tests automa
       console.log(colors.cyan(`>> File ${display_path} changed.`));
       run_tests();
     },
+    preferredMethods: ["watchFile", "watch"],
     persistent: true,
     interval: 100, // use values from grunt-contrib-watch
     catchupDelay: 500

--- a/truffle.es6
+++ b/truffle.es6
@@ -336,9 +336,9 @@ registerTask('watch:tests', "Watch filesystem for changes and rerun tests automa
   gaze(["app/**/*", "config/**/*", "contracts/**/*", "test/**/*"], {cwd: working_dir, interval: 1000, debounceDelay: 500}, function() {
     // On changed/added/deleted
     this.on('all', function(event, filePath) {
-      if (filePath.match(/\/config\/.*?\/contracts\.json$/)) {
-        // ignore changes to /config/*/contracts.json since these changes every time
-        // tests are run
+      if (filePath.match(/\/config\/.*?\/.*?\.sol\.js$/)) {
+        // ignore changes to /config/*/*.sol.js since these changes every time
+        // tests are run (when contracts are compiled)
         return;
       }
       process.stdout.write("\u001b[2J\u001b[0;0H"); // clear screen


### PR DESCRIPTION
### Changes in this PR:

* added watch:tests task - uses gaze to re-rerun tests automatically. this helps reduce the startup lag between test runs for more immediate feedback
* allow redeploying contracts from within tests
* use evm snapshot/revert before/after tests instead of redeploying
* display Event logs on test failures

### Possible TODOs:
* refactor test code
* readme updates
* ~~only use snapshot/revert if the server supports it (can test for it before suite)~~ (implemented)

Logs look something like this:

```
    1) should be able to transfer records

    Events emitted during test:
    ---------------------------
[DEBUG] Initializing account
[DEBUG] Adding value to account
{ event: 'Deposit',
  data: 
   { _from: '0x82a978b3f5962a5b0957d9ee9eef472ee55b42f1',
     _id: '0x666f6f6261720000000000000000000000000000000000000000000000000000',
     _value: '10000',
     status: 'success' } }
{ event: 'Deposit',
  data: 
   { _from: '0x82a978b3f5962a5b0957d9ee9eef472ee55b42f1',
     _id: '0x666f6f6261720000000000000000000000000000000000000000000000000000',
     _value: '10000',
     status: 'success' } }
[DEBUG] Adding value to account
{ event: 'Deposit',
  data: 
   { _from: '0x82a978b3f5962a5b0957d9ee9eef472ee55b42f1',
     _id: '0x666f6f6261720000000000000000000000000000000000000000000000000000',
     _value: '10000',
     status: 'success' } }

    --------------------------- END EVENTS
    ✓ should be able to be killed (636ms)


  10 passing (7s)
  1 failing

  1) Contract: Bank should be able to transfer records:
     AssertionError: assert.fail()
    at /tmp/truffle-115926-24254-166e646-bank.coffee:111:16
    at tryCatcher (node_modules/bluebird/js/main/util.js:26:23)
    at Promise._settlePromiseFromHandler (node_modules/bluebird/js/main/promise.js:507:31)
    at Promise._settlePromiseAt (node_modules/bluebird/js/main/promise.js:581:18)
    at Promise._settlePromises (node_modules/bluebird/js/main/promise.js:697:14)
    at Async._drainQueue (node_modules/bluebird/js/main/async.js:123:16)
    at Async._drainQueues (node_modules/bluebird/js/main/async.js:133:10)
    at Immediate.Async.drainQueues [as _onImmediate] (node_modules/bluebird/js/main/async.js:15:14)
    at Function.module.exports.loopWhile (node_modules/deasync/index.js:64:21)
    at node_modules/deasync/index.js:36:18
    at runTask (truffle.es6:55:5)
    at Object.<anonymous> (truffle.es6:376:14)
    at normalLoader (node_modules/babel/node_modules/babel-core/lib/api/register/node.js:199:5)
    at Object.require.extensions.(anonymous function) [as .es6] (node_modules/babel/node_modules/babel-core/lib/api/register/node.js:216:7)
    at Object.<anonymous> (node_modules/babel/lib/_babel-node.js:144:25)
    at node.js:961:3
```

