### PR TITLE
Implementation of solidity library linking

### DIFF
--- a/example/contracts/ConvertLib.sol
+++ b/example/contracts/ConvertLib.sol
@@ -1,0 +1,6 @@
+library ConvertLib{
+	function convert(uint amount,uint conversionRate) returns (uint convertedAmount)
+	{
+		return amount * conversionRate;
+	}
+}

--- a/example/contracts/MetaCoin.sol
+++ b/example/contracts/MetaCoin.sol
@@ -1,3 +1,5 @@
+import "ConvertLib.sol";
+
 contract MetaCoin {
 	mapping (address => uint) balances;
 
@@ -11,8 +13,10 @@ contract MetaCoin {
 		balances[receiver] += amount;
 		return true;
 	}
-
-  function getBalance(address addr) returns(uint) {
-    return balances[addr];
-  }
+	function getBalanceInEth(address addr) returns(uint){
+		return ConvertLib.convert(getBalance(addr),2);
+	}
+  	function getBalance(address addr) returns(uint) {
+    	return balances[addr];
+  	}
 }

--- a/example/test/metacoin.js
+++ b/example/test/metacoin.js
@@ -6,7 +6,22 @@ contract('MetaCoin', function(accounts) {
       assert.equal(balance.valueOf(), 10000, "10000 wasn't in the first account");
     }).then(done).catch(done);
   });
+  it("should call a function that depends on a linked library  ", function(done){
+    var meta = MetaCoin.deployed();
+    var metaCoinBalance;
+    var metaCoinEthBalance;
 
+    meta.getBalance.call(accounts[0]).then(function(outCoinBalance){
+      metaCoinBalance = outCoinBalance.toNumber();
+      return meta.getBalanceInEth.call(accounts[0]);
+    }).then(function(outCoinBalanceEth){
+      metaCoinEthBalance = outCoinBalanceEth.toNumber();
+      
+    }).then(function(){
+      assert.equal(metaCoinEthBalance,2*metaCoinBalance,"Library function returned unexpeced function, linkage may be broken");
+      
+    }).then(done).catch(done);
+  });
   it("should send coin correctly", function(done) {
     var meta = MetaCoin.deployed();
 

--- a/example/truffle.js
+++ b/example/truffle.js
@@ -10,7 +10,8 @@ module.exports = {
     "images/": "images/"
   },
   deploy: [
-    "MetaCoin"
+    "MetaCoin",
+    "ConvertLib"
   ],
   rpc: {
     host: "localhost",

--- a/lib/contracts.es6
+++ b/lib/contracts.es6
@@ -10,6 +10,12 @@ var PuddingGenerator = require("ether-pudding/generator");
 var ConfigurationError = require("./errors/configurationerror");
 var CompileError = require("./errors/compileerror");
 var DeployError = require("./errors/deployerror");
+var Graph = require("graphlib").Graph;
+var isAcyclic = require("graphlib/lib/alg").isAcyclic;
+var preOrder = require("graphlib/lib/alg").preorder;
+var postOrder = require("graphlib/lib/alg").postorder;
+
+var BlueBirdPromise = require('bluebird');
 
 var Contracts = {
   resolve_headers(root) {
@@ -185,34 +191,99 @@ var Contracts = {
       }
     ], callback);
   },
-
-  createContractAndWait(config, tx) {
+  createContractAndWait(config, tx,contract_name) {
+  
     return new Promise((accept, reject) => {
+      
       config.web3.eth.sendTransaction(tx, (err, hash) => {
         if (err != null) {
           return reject(err);
         }
 
         var interval = setInterval(() => {
+         
           config.web3.eth.getTransactionReceipt(hash, (err, receipt) => {
             if (err != null) {
               clearInterval(interval);
+              
               return reject(err);
             }
-
             if (receipt != null) {
-              accept(receipt.contractAddress);
+               console.log("Deployed: "+contract_name+" to address: "+receipt.contractAddress);
+           
+              accept({name:contract_name,address:receipt.contractAddress});
               clearInterval(interval);
             }
           });
+
         }, 1000);
       })
     });
   },
+  build_dependency_graph(config,errorCallback)
+  {     
+        console.log("Collecting dependencies...");
+        //Iterate through all the contracts looking for libraries and building a dependency graph 
+        var dependsGraph = new Graph();
+        for (var i = 0; i < config.app.resolved.deploy.length; i++) {
+          var key = config.app.resolved.deploy[i];
+          var contract_class = config.contracts.classes[key];
 
+          if (contract_class == null) {
+            errorCallback(new DeployError(`Error  could not find contract '${key}' for linking. Check truffle.json.`));
+            return null;
+          }
+          //Add the contract to the depend graph  
+          dependsGraph.setNode(key);
+
+          //Find references to any librarys 
+          //Library references are embedded in the bytecode of contracts with the format
+          // "__Lib___________________________________" , where "Lib" is your library name and the whole
+          // string is 40 characters long. This is the placeholder for the Lib's address.
+
+          var regex = /__([^_]*)_*/g;
+          var matches;
+          while ( (matches = regex.exec(contract_class.binary)) !== null ) {
+                var lib = matches[1];
+                if(!dependsGraph.hasEdge(key,lib))
+                   dependsGraph.setEdge(key, lib);
+          }
+        }
+        //Check for cycles in the graph, the dependency graph needs to be a tree otherwise there's an error
+        if(!isAcyclic(dependsGraph))
+        {
+           console.log("ERROR: Cycles in dependency graph");
+           dependsGraph.edges().forEach(function(o){
+              console.log(o.v+" -- depends on --> "+o.w);
+           });
+           errorCallback(new DeployError(`Error  linker found cyclic dependencies. Adjust your import statements to remove cycles.`));
+           return null;
+        }
+        return dependsGraph;
+       
+  },
+  link_dependencies(config,contract_data,contract_class,contract_name)
+  {
+    return (dependency_addresses) => {
+          //All of the library dependencies to this contract have been deployed
+          //Inject the address of each lib into this contract and then deploy it.
+          dependency_addresses.forEach(function(lib){
+            console.log("Linking Library: "+lib.name+" to contract: "+contract_name+" at address: "+lib.address);
+            var bin_address = lib.address.replace("0x","");
+            var re = new RegExp("__"+lib.name+"_*","g");
+            contract_data.data = contract_data.data.replace(re,bin_address);
+          });
+          var contract = Pudding.whisk({
+              abi: contract_class.abi,
+              binary: contract_class.binary,
+              contract_name: contract_name
+            });
+          return this.createContractAndWait(config,contract_data,contract_name);
+    }
+  },
   deploy(config, compile=true, done_deploying) {
     var coinbase = null;
-
+    
     async.series([
       (c) => {
         config.web3.eth.getCoinbase(function(error, result) {
@@ -227,56 +298,83 @@ var Contracts = {
           c();
         }
       },
-      (c) => {
-        Pudding.setWeb3(config.web3);
+      (c) =>{
+          Pudding.setWeb3(config.web3);
+          var dependsGraph = this.build_dependency_graph(config,c);
+          var dependsOrdering = postOrder(dependsGraph,dependsGraph.nodes());
+          var deploy_promise = null;
+          var contract_name ; //This is in global scope so that it can be used in the .catch below
 
-        var txs = [];
 
-        for (var i = 0; i < config.app.resolved.deploy.length; i++) {
-          var key = config.app.resolved.deploy[i];
-          var contract_class = config.contracts.classes[key];
+          //Iterate over the dependency grpah in post order, deploy libraries first so we can
+          //capture their addresses and use them to deploy the contracts that depend on them
+          for(var i =0 ; i< dependsOrdering.length ;i++)
+          {
+              contract_name = dependsOrdering[i];
+              var contract_class = config.contracts.classes[contract_name];
+              
+              if (contract_class == null) {
+                c(new DeployError(`Could not find contract '${key}' for deployment. Check truffle.json.`));
+                return;
+              }
+             
+              var contract_data = { from: coinbase,
+                                    gas: 3141592,
+                                    //gasPrice: 50000000000, // 50 Shannon
+                                    gasPrice: 100000000000, // 100 Shannon
+                                    data: contract_class.binary
+                                  };
+              var dependencies = dependsGraph.successors(contract_name);
 
-          if (contract_class == null) {
-            c(new DeployError(`Could not find contract '${key}' for deployment. Check truffle.json.`));
-            return;
+              //When we encounter a Library that is not dependant on other libraries, we can just
+              //deploy it as normal
+              if(dependencies.length == 0 )
+              {
+                 var contract = Pudding.whisk({
+                  abi: contract_class.abi,
+                  binary: contract_class.binary,
+                  contract_name: contract_name
+                });
+                deploy_promise = this.createContractAndWait(config,contract_data,contract_name);
+
+                //Store the promise in the graph so we can fetch it later
+                dependsGraph.setNode(contract_name,deploy_promise);
+              }
+              //Contracts that have dependencies need to wait until those dependencies have been deployed
+              //so we can inject the address into their byte code 
+              else
+              {
+                //Collect all the promises for the libraries this contract depends on into a list
+                //NOTE: since this loop is traversing in post-order, we can be assured that this list
+                //will contain ALL of the dependencies of this contract
+                var depends_promises = dependencies.map(dependsGraph.node,dependsGraph);
+
+                //Wait for all the dependencies to be committed and then do the linking step
+                deploy_promise = Promise.all(depends_promises)
+                                        .then(this.link_dependencies(config,contract_data,contract_class,contract_name));
+                
+                //It's possible that this contract is a dependency of some other contract so we store
+                //it in the graph just in case
+                dependsGraph.setNode(contract_name,deploy_promise);
+               
+              }
           }
+          ///Now wait for all of the outstanding deployments to complete
+          Promise.all(dependsGraph.nodes().map(dependsGraph.node,dependsGraph))
+          .then(function(deployed_contracts) {
 
-          var contract = Pudding.whisk({
-            abi: contract_class.abi,
-            binary: contract_class.binary,
-            contract_name: key
+            deployed_contracts.forEach(function(a){config.contracts.classes[a.name].address = a.address;});
+            
+            c();
+          }).catch(function(err) {
+            c(new DeployError(err.message, contract_name));
           });
 
-          var display_name = path.basename(contract_class.source);
-          if (config.argv.quietDeploy == null) {
-            console.log(`Sending ${display_name} to the network...`);
-          }
-
-          txs.push(this.createContractAndWait(config, {
-            from: coinbase,
-            gas: 3141592,
-            //gasPrice: 50000000000, // 50 Shannon
-            gasPrice: 100000000000, // 100 Shannon
-            data: contract_class.binary
-          }));
-        }
-
-        Promise.all(txs).then(function(addresses) {
-          for (var i = 0; i < addresses.length; i++) {
-            var address = addresses[i];
-            var key = config.app.resolved.deploy[i];
-            var contract_class = config.contracts.classes[key];
-            contract_class.address = address;
-          }
-          c();
-        }).catch(function(err) {
-          c(new DeployError(err.message, key));
-        });
       },
-      (c) => {
+    (c) => {
         this.write_contracts(config, "built contract files", c);
-      },
-      (c) => {
+    },
+    (c) => {
         this.after_deploy(config, c);
       }
     ], (err) => {

--- a/lib/contracts.es6
+++ b/lib/contracts.es6
@@ -233,6 +233,12 @@ var Contracts = {
             errorCallback(new DeployError(`Error  could not find contract '${key}' for linking. Check truffle.json.`));
             return null;
           }
+          console.log("BINARY: "+contract_class.binary);
+              
+          if(contract_class.binary == null){
+            errorCallback(new DeployError(`Error  could not find compiled binary for contract '${key}'. Check truffle.json.`));
+            return null;
+          }
           //Add the contract to the depend graph  
           dependsGraph.setNode(key);
 
@@ -294,19 +300,24 @@ var Contracts = {
       (c) => {
         if (compile == true) {
           this.compile_all(config, c);
+
         } else {
           c();
         }
       },
       (c) =>{
+          
+
           Pudding.setWeb3(config.web3);
           var dependsGraph = this.build_dependency_graph(config,c);
+          if(dependsGraph == null)
+             return;
+          
           var dependsOrdering = postOrder(dependsGraph,dependsGraph.nodes());
           var deploy_promise = null;
           var contract_name ; //This is in global scope so that it can be used in the .catch below
 
-
-          //Iterate over the dependency grpah in post order, deploy libraries first so we can
+         //Iterate over the dependency grpah in post order, deploy libraries first so we can
           //capture their addresses and use them to deploy the contracts that depend on them
           for(var i =0 ; i< dependsOrdering.length ;i++)
           {
@@ -317,7 +328,7 @@ var Contracts = {
                 c(new DeployError(`Could not find contract '${key}' for deployment. Check truffle.json.`));
                 return;
               }
-             
+
               var contract_data = { from: coinbase,
                                     gas: 3141592,
                                     //gasPrice: 50000000000, // 50 Shannon
@@ -335,6 +346,7 @@ var Contracts = {
                   binary: contract_class.binary,
                   contract_name: contract_name
                 });
+
                 deploy_promise = this.createContractAndWait(config,contract_data,contract_name);
 
                 //Store the promise in the graph so we can fetch it later

--- a/lib/contracts.es6
+++ b/lib/contracts.es6
@@ -233,8 +233,7 @@ var Contracts = {
             errorCallback(new DeployError(`Error  could not find contract '${key}' for linking. Check truffle.json.`));
             return null;
           }
-          console.log("BINARY: "+contract_class.binary);
-              
+               
           if(contract_class.binary == null){
             errorCallback(new DeployError(`Error  could not find compiled binary for contract '${key}'. Check truffle.json.`));
             return null;

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "ether-pudding": "2.0.1",
     "finalhandler": "^0.4.0",
     "gaze": "^0.5.2",
+    "graphlib": "^2.0.0",
     "jsmin": "^1.0.1",
     "lodash": "^3.10.1",
     "mkdirp": "^0.5.1",
@@ -55,5 +56,8 @@
       "email": "tim@timothyjcoulter.com",
       "url": "https://github.com/tcoulter"
     }
-  ]
+  ],
+  "devDependencies": {
+    "babel-cli": "^6.4.5"
+  }
 }

--- a/truffle.es6
+++ b/truffle.es6
@@ -222,10 +222,12 @@ registerTask('deploy', "Deploy contracts to the network", function(done) {
   console.log("Using environment " + config.environment + ".");
 
   var compile = true;
+  var link = true;
 
   if (argv.compile === false) {
     compile = false;
   }
+ 
 
   // Compile and deploy.
   Contracts.deploy(config, compile, function(err) {


### PR DESCRIPTION
Added the ability to link solidity libraries to the contract deploy process. The process follows the following flow:

1. Builds a dependency graph for libraries of all the contracts in the deploy list. This also handles libraries that are dependent on other libraries. We do this by inspecting the compiled binaries for the `__[LibName]_____________________________` marker as documented in the solidity compiler docs.
https://solidity.readthedocs.org/en/latest/contracts.html?highlight=library 

2. Deploys the contracts and libraries based on the dependency graph such that contracts and libraries that have dependencies wait until their dependencies have been deployed and a deploy address has been captured.

3. Inject the deploy address of dependencies into the bytecode using the above marker

There is also a new example library contract and unit test in the example folder to illustrate how to use this feature in practice.

NOTE: Added a dependency for the project to a graph library used to build the dependency tree: https://github.com/cpettitt/graphlib


