### PR TITLE
Adding support for multiple contracts in the same file to be handled correctly

### DIFF
--- a/lib/config.es6
+++ b/lib/config.es6
@@ -54,6 +54,7 @@ var Config = {
         }
       },
       contracts: {
+        filenames: {},
         classes: {},
         directory: `${working_dir}/contracts`,
         build_directory: null
@@ -215,8 +216,17 @@ var Config = {
       for (file of filesSync(config.contracts.directory)) {
         var name = file.substring(file.lastIndexOf("/") + 1, file.lastIndexOf("."));
         var relative_path = file.replace(config.working_dir, "./");
-        config.contracts.classes[name] = {
+        config.contracts.filenames[name] = {
           source: relative_path
+        }
+        var code = fs.readFileSync(file, {encoding: "utf8"});
+        var myRegex = /contract\s([a-zA-Z0-9_\-]+)/g;
+        var match = myRegex.exec(code);
+        while (match != null){
+          config.contracts.classes[match[1]] = {
+            source: "./" + match[1] + ".sol"
+          }
+          match = myRegex.exec(code);
         }
       }
     }

--- a/lib/contracts.es6
+++ b/lib/contracts.es6
@@ -115,10 +115,10 @@ var Contracts = {
 
   compile_all(config, callback) {
     var sources = {};
-    var contracts = Object.keys(config.contracts.classes);
+    var contracts = Object.keys(config.contracts.filenames);
     for (var i = 0; i < contracts.length; i++) {
       var key = contracts[i];
-      var contract = config.contracts.classes[key];
+      var contract = config.contracts.filenames[key];
       var source = contract.source.replace("./contracts/", "");
       var full_path = path.resolve(config.working_dir, contract.source)
       sources[source] = fs.readFileSync(full_path, {encoding: "utf8"});
@@ -131,14 +131,14 @@ var Contracts = {
       return;
     }
 
-    var compiled_contract = result.contracts[key];
-
-    for (var i = 0; i < contracts.length; i++) {
-      var key = contracts[i];
-      var contract = config.contracts.classes[key];
-      var compiled_contract = result.contracts[key];
-      contract["binary"] = compiled_contract.bytecode;
-      contract["abi"] = JSON.parse(compiled_contract.interface);
+    for (var contractKey in result.contracts){
+      if(result.contracts.hasOwnProperty(contractKey)){
+        config.contracts.classes[contractKey] = {
+          source: "./" + contractKey + ".sol",
+          binary: result.contracts[contractKey].bytecode,
+          abi: JSON.parse(result.contracts[contractKey].interface)
+        }
+      }
     }
 
     callback();


### PR DESCRIPTION
Here is the argument against "Just put all your contracts in separate files".

1. I have a hub contract and a spoke contract.
2. I have set them up so that the hub has calls into the spoke and the spoke has calls back into the hub.
3. If they are in separate files I have to include an import from each contract into the other and solc complains that the contract already exists.
4. If I remove the import from either file solc complains about type not found.
5. The only way to keep solc happy is to put both contracts in the same file.

The crux of this change is to introduce config.contracts.filenames (which I think is more accurate for what it does) and then to parse the contract files at config creation time and use regex to extract the names of the contracts and put those into config.contracts.classes.  contracts.es6 is updated to accommodate that change.