### PR TITLE
Take mocha config from truffle.json

### DIFF
--- a/lib/test.es6
+++ b/lib/test.es6
@@ -441,7 +441,7 @@ var Test = {
         throw e;
       });
 
-      var mocha = new Mocha({
+      var mocha = new Mocha(config.app.resolved.mocha || {
         useColors: true
       });
 
@@ -475,7 +475,7 @@ var Test = {
         //   return f;
         // });
 
-        var mocha = new Mocha({
+        var mocha = new Mocha(config.app.resolved.mocha || {
           useColors: true
         });
 


### PR DESCRIPTION
If present in truffle.json, the contents of the 'mocha' key will be
used as the arguments passed to `new Mocha()`. This is 
useful for e.g. using a different test reporter in CI.