### PR TITLE
Update documentation. Fix spelling and formatting.

### DIFF
--- a/docs/advanced/commands.md
+++ b/docs/advanced/commands.md
@@ -6,7 +6,7 @@ $ truffle [command] [options]
 
 # Available Commands
 
-##### build           
+##### build
 
 Build a development version of the app; creates the `./environments/<name>/build` directory.
 
@@ -28,7 +28,7 @@ Run a console with your contract objects instantiated and ready to use (REPL).
 $ truffle console
 ```
 
-Once the console starts you can then use your contracts via the command line like you would in your code.
+Once the console starts, you can then use your contracts via the command line like you would in your code.
 
 Optional parameters:
 
@@ -79,7 +79,7 @@ Optional parameters:
 
 Deploying contracts will save [Pudding](https://github.com/ConsenSys/ether-pudding) class files within your environment's `contracts` directory that correspond to each of your contracts. These class files can be used in Truffle's build process or your own build process to interact with the Ethereum network.
 
-##### dist (deprecated)      
+##### dist (deprecated)
 
 Build a distributable version of the app; creates the `./environments/<name>/dist` directory.
 
@@ -143,14 +143,6 @@ List all available commands and exit. Synonymous with `--help`.
 
 ```none
 $ truffle list
-```
-
-##### resolve
-
-Resolve all dependencies within solidity files and print the result.
-
-```none
-$ truffle resolve ./path/to/contract/file.sol
 ```
 
 ##### serve

--- a/docs/advanced/environments.md
+++ b/docs/advanced/environments.md
@@ -23,7 +23,7 @@ In this case, Truffle will deploy new versions of your deployable contracts to t
 
 # Environment Configuration
 
-You can override the default project configuration within each of your environments by editing the environment's `config.json` file. This is a JSON file instead of a Javascript file, contrary to `truffle.js`. Future versions of Truffle will convert these files to Javascript files so they can act more like your global project configuration. For now, however, you must specify these overrides via JSON. Consider this example:
+You can override the default project configuration within each of your environments by editing the environment's `config.js` file. This is a Javascript file that overrides the global project configuration specified in `truffle.js`. Consider this example:
 
 **truffle.js**
 ```javascript
@@ -35,12 +35,12 @@ module.exports = {
 }
 ```
 
-**./environments/production/config.json**
+**./environments/production/config.js**
 ```javascript
-{
-  "rpc": {
-    "host": "192.168.1.144" // domain of ethereum client pointing to live network
-    "port": 8673            // custom port
+module.exports = {
+  rpc: {
+    host: "192.168.1.144", // domain of ethereum client pointing to live network
+    port: 8673             // custom port
   }
 }
 ```
@@ -49,7 +49,7 @@ In this example, when running `truffle deploy` Truffle will deploy to an Ethereu
 
 # Build Artifacts
 
-Except for the `config.json` file located in each environment, every other file within your environment's directory is a build artifact. These artifacts are organized in two ways:
+Except for the `config.js` file located in each environment, every other file within your environment's directory is a build artifact. These artifacts are organized in two ways:
 
 * `build`: Directory of built frontend. When using the [default builder](/getting_started/build), `truffle build` will automatically place build artifacts here.
 * `contracts`: Directory containing compiled contract output. These files have the extension ".sol.js", and are created by [Ether Pudding](https://github.com/ConsenSys/ether-pudding) to be easily integrated into any build process.

--- a/docs/getting_started/contracts.md
+++ b/docs/getting_started/contracts.md
@@ -17,7 +17,7 @@ Transactions fundamentally change the state of the network. A transaction can be
 
 ### Calls
 
-Calls, on the other hand, are very different. Calls can be used to execute code on the network, though no data will be permanently changed. Calls are free to run, and they're defining characteristic is that they read data. When you execute a contract function via a call you will receive the return value immediately. In summary, calls:
+Calls, on the other hand, are very different. Calls can be used to execute code on the network, though no data will be permanently changed. Calls are free to run, and their defining characteristic is that they read data. When you execute a contract function via a call you will receive the return value immediately. In summary, calls:
 
 * Are free (do not cost gas)
 * Do not change the state of the network
@@ -47,8 +47,8 @@ contract MetaCoin {
   	return true;
   }
 
-  function getBalanceInEth(address addr) returns(uint){
-  	return ConvertLib.convert(getBalance(addr),2);
+  function getBalanceInEth(address addr) returns(uint) {
+  	return ConvertLib.convert(getBalance(addr), 2);
   }
 
   function getBalance(address addr) returns(uint) {
@@ -98,7 +98,7 @@ meta.sendCoin(account_two, 10, {from: account_one}).then(function(tx_id) {
   // this callback.
   alert("Transaction successful!")
 }).catch(function(e) {
-  // There was an error! Handle it.  
+  // There was an error! Handle it.
 })
 ```
 
@@ -123,7 +123,7 @@ meta.getBalance.call(account_one, {from: account_one}).then(function(balance) {
   // Let's print the return value.
   console.log(balance.toNumber());
 }).catch(function(e) {
-  // There was an error! Handle it.  
+  // There was an error! Handle it.
 })
 ```
 
@@ -165,7 +165,7 @@ MetaCoin.new().then(function(instance) {
   // If this callback is called, the deployment was successful.
   console.log(instance.address);
 }).catch(function(e) {
-  // There was an error! Handle it.  
+  // There was an error! Handle it.
 });
 ```
 


### PR DESCRIPTION
Updated documentation to match Truffle v.1.0.1

-fixed spelling and formatting
-fixed description of environment configuration settings to use config.js rather than config.json
-removed description of `truffle resolve` cli command