### PR TITLE
Dynamically discover contracts to deploy from the contracts folder

### DIFF
--- a/example/truffle.js
+++ b/example/truffle.js
@@ -1,3 +1,5 @@
+var fs = require('fs');
+
 module.exports = {
   build: {
     "index.html": "index.html",
@@ -9,10 +11,7 @@ module.exports = {
     ],
     "images/": "images/"
   },
-  deploy: [
-    "MetaCoin",
-    "ConvertLib"
-  ],
+  deploy: fs.readdirSync('contracts').map(function(c) { return c.replace(/\.sol$/i, '') }),
   rpc: {
     host: "localhost",
     port: 8545


### PR DESCRIPTION
Instead of the need to manually list contracts in the deploy config array this PR changes the config to scan the contracts folder for all .sol files automatically.

I'm very new to the truffle ecosystem. While experimenting with it I had the error that I forgot to add a contract to the deploy array. 
Because it seems that it is a required convention to have the contracts in the `contracts` folder I was wondering why not dynamically scan for all contract files? 
Maybe this could also be an internal default which can be overwritten in the custom truffle.js - this would keep the custom truffle.js smaller and a default giving users less to think about?

Actually the same also applies to the app.{js,css} files.  (though I am not sure if I personally don't prefer going with some other the many other existing JS build tools out there) 
I am happy to extend this, but because I am very new here I was wondering about your thoughts. 


P.S. thanks for delicious truffle