### PR TITLE
Bump ether-pudding version

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "colors": "^1.1.2",
     "cpr": "^0.4.3",
     "deasync": "^0.1.3",
-    "ether-pudding": "2.0.6",
+    "ether-pudding": "^2.0.6",
     "finalhandler": "^0.4.0",
     "graphlib": "^2.0.0",
     "jsmin": "^1.0.1",


### PR DESCRIPTION
I don't know for sure if you're abiding by semver with ether-pudding, but I've not been caught out yet, hence I think the caret is a good addition to prevent PRs like this being needed later.

If you disagree, I'll hardcode v2.0.8 and rebase.

NB I've not taken the liberty of bumping the truffle version, though I could do that too and rebase if desired - I know you're spinning a lot of plates!