### PR TITLE
Fix library linking for contracts that depends on multiple libraries

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -36,6 +36,7 @@ var Config = {
           build: {},
           include_contracts: true,
           deploy: [],
+          libraries: [],
           after_deploy: [],
           rpc: {},
           processors: {},

--- a/lib/contracts.js
+++ b/lib/contracts.js
@@ -75,7 +75,7 @@ var Contracts = {
       }
 
       var dependsGraph = self.build_compile_dependency_graph(config, callback);
-
+      self.compilationDependenciesGraph = dependsGraph;
       if (dependsGraph == null) {
         return;
       }
@@ -212,6 +212,88 @@ var Contracts = {
     ], callback);
   },
 
+
+  //############## Deploy libraries from a list
+
+  /**
+   * Deploy all libraries from config.app.resolved.libraries (truffle.js)
+   * @param  {object}     config      the configuration parameters object
+   * @param  {function}   callback    callback to be called when the process is over
+   */
+  deployLibraries: function(config, callback) {
+
+    var self = this;
+    self.libraries = [];
+    if(config.app.resolved.libraries.length === 0) return;
+
+    Pudding.setWeb3(config.web3);
+    var promises = [];
+
+    //fetch all libraries from config
+    for (var i = 0; i < config.app.resolved.libraries.length; i++) {
+      //iterate over them and deploy them
+      var contract_name = config.app.resolved.libraries[i];
+      var contract_class = config.contracts.classes[contract_name];
+      // if (config.argv.quietDeploy == null) {
+        console.log('Deploying library : ', contract_name);
+      // }
+
+      promises[promises.length++] = self.createContractAndWait(config, contract_name);
+    }
+
+    //use Promise.all to wait for all libraries to be deployed
+    Promise.all(promises)
+    .then(function(librariesDeployed){
+
+      for(var i = 0; i < librariesDeployed.length; i++) {
+        var library = librariesDeployed[i];
+        self.libraries[library.name] = library.address;
+        self.linkLibrary(config, library, library.name);
+      }
+
+      if(callback) callback();
+    })
+    .catch(function(error){
+      callback(error);
+    });
+  },
+  /**
+   * Used to iterate recursively through the graph finding library dependent contracts and link them
+   * @param  {object}     library         the deployed library to be linked, e.g: "{ name: 'ConvertLib', address: '0x0000000000000'}".
+   * @param  {string}     contractName    this parameter carries the name of the contract/library to be used to look for dependencies.
+   */
+  linkLibrary: function(config, library, contractName) {
+
+    console.log('linkLibrary: ', contractName);
+    if(config.app.resolved.deploy.indexOf(contractName) !== -1) return;
+
+    var self = this;
+    var dependencies = self.compilationDependenciesGraph.predecessors(contractName);
+    if(dependencies && dependencies.length > 0) {
+
+      var idxDependency = dependencies.length-1;
+      while(idxDependency >= 0)
+      {
+        var dependency = dependencies[idxDependency];
+        self.linkLibrary(config, library, dependency);
+
+        idxDependency--;
+      }
+    }
+
+    if(contractName === library.name) return;
+
+    // if(config.argv.quietDeploy == null) {
+      console.log('Linking library : ', library.name, ' to contract: ', contractName);
+    // }
+
+    var contract = config.contracts.classes[contractName];
+    var libraryBinAddress = library.address.replace("0x", "");
+    var regex = new RegExp("__" + library.name + "_*", "g");
+    config.contracts.classes[contractName].binary = contract.unlinked_binary.replace(regex, libraryBinAddress);
+  },
+  //############## Deploy libraries from a list
+
   createContractAndWait: function(config, contract_name) {
     var self = this;
 
@@ -247,7 +329,7 @@ var Contracts = {
               clearInterval(interval);
             }
           });
-        }, 500);
+        }, 1000);
       })
     });
   },
@@ -383,6 +465,7 @@ var Contracts = {
       compile == true;
     }
 
+    compile = true;
     async.series([
       function(c) {
         self.get_account(config, c);
@@ -394,6 +477,18 @@ var Contracts = {
           c();
         }
       },
+      //############## Deploy libraries from a list
+      function(c) {
+        if(compile && config.app.resolved.libraries && config.app.resolved.libraries.length > 0) {
+          self.deployLibraries(config, c);
+        } else {
+          c();
+        }
+      },
+      function(c) {
+        self.write_contracts(config, "built contract files", c);
+      },
+      //############## Deploy libraries from a list
       function(c) {
         Pudding.setWeb3(config.web3);
         var dependsGraph = self.build_deploy_dependency_graph(config, c);
@@ -410,6 +505,7 @@ var Contracts = {
         // capture their addresses and use them to deploy the contracts that depend on them
         for(var i = 0; i < dependsOrdering.length; i++) {
           contract_name = dependsOrdering[i];
+          console.log('Deploy contract name: ', contract_name);
           var contract_class = config.contracts.classes[contract_name];
 
           if (contract_class == null) {

--- a/lib/contracts.js
+++ b/lib/contracts.js
@@ -44,7 +44,6 @@ var Contracts = {
       var contract = config.contracts.classes[name];
       fs.readFile(contract.file, {encoding: "utf8"}, function(err, body) {
         if (err) return done(err);
-
         contract.body = body;
         done();
       });
@@ -234,9 +233,9 @@ var Contracts = {
       //iterate over them and deploy them
       var contract_name = config.app.resolved.libraries[i];
       var contract_class = config.contracts.classes[contract_name];
-      // if (config.argv.quietDeploy == null) {
+      if (config.argv.quietDeploy == null) {
         console.log('Deploying library : ', contract_name);
-      // }
+      }
 
       promises[promises.length++] = self.createContractAndWait(config, contract_name);
     }
@@ -247,7 +246,7 @@ var Contracts = {
 
       for(var i = 0; i < librariesDeployed.length; i++) {
         var library = librariesDeployed[i];
-        self.libraries[library.name] = library.address;
+        self.libraries[library.name] = { name: library.name, address: library.address, dependencies: [] };
         self.linkLibrary(config, library, library.name);
       }
 
@@ -263,14 +262,21 @@ var Contracts = {
    * @param  {string}     contractName    this parameter carries the name of the contract/library to be used to look for dependencies.
    */
   linkLibrary: function(config, library, contractName) {
-
-    console.log('linkLibrary: ', contractName);
-    if(config.app.resolved.deploy.indexOf(contractName) !== -1) return;
-
     var self = this;
+    if(!library) return;
+
+    var preDeployedLib = self.libraries[library.name];
+    if(preDeployedLib && preDeployedLib.dependencies.indexOf(contractName) === -1) {
+      if(contractName !== library.name) {
+        self.libraries[library.name].dependencies.push(contractName);
+      }
+    }
+
+    if(config.app.resolved.deploy.indexOf(contractName) !== -1) return;
+    if(!self.compilationDependenciesGraph) return;
+
     var dependencies = self.compilationDependenciesGraph.predecessors(contractName);
     if(dependencies && dependencies.length > 0) {
-
       var idxDependency = dependencies.length-1;
       while(idxDependency >= 0)
       {
@@ -282,15 +288,16 @@ var Contracts = {
     }
 
     if(contractName === library.name) return;
-
-    // if(config.argv.quietDeploy == null) {
-      console.log('Linking library : ', library.name, ' to contract: ', contractName);
-    // }
-
     var contract = config.contracts.classes[contractName];
     var libraryBinAddress = library.address.replace("0x", "");
     var regex = new RegExp("__" + library.name + "_*", "g");
-    config.contracts.classes[contractName].binary = contract.unlinked_binary.replace(regex, libraryBinAddress);
+    var usingLibrary = regex.test(contract.binary);
+
+    if(usingLibrary) {
+      config.contracts.classes[contractName].binary = contract.binary.replace(regex, libraryBinAddress);
+    } else {
+      config.contracts.classes[contractName].binary = contract.unlinked_binary.replace(regex, libraryBinAddress);
+    }
   },
   //############## Deploy libraries from a list
 
@@ -305,6 +312,19 @@ var Contracts = {
     };
 
     return new Promise(function(accept, reject) {
+
+      if(self.libraries) {
+        var preDeployedLib = self.libraries[contract_name];
+        if(preDeployedLib)
+        {
+          return accept({
+            name: preDeployedLib.name,
+            address: preDeployedLib.address
+          });
+        }
+      }
+
+
       config.web3.eth.sendTransaction(tx, function(err, hash) {
         if (err != null) {
           return reject(err);
@@ -314,9 +334,9 @@ var Contracts = {
           config.web3.eth.getTransactionReceipt(hash, function(err, receipt) {
             if (err != null) {
               clearInterval(interval);
-
               return reject(err);
             }
+
             if (receipt != null) {
               if (config.argv.quietDeploy == null) {
                 console.log("Deployed: " + contract_name + " to address: " + receipt.contractAddress);
@@ -326,10 +346,11 @@ var Contracts = {
                 name: contract_name,
                 address: receipt.contractAddress
               });
+
               clearInterval(interval);
             }
           });
-        }, 1000);
+        }, 500);
       })
     });
   },
@@ -440,6 +461,17 @@ var Contracts = {
       //All of the library dependencies to this contract have been deployed
       //Inject the address of each lib into this contract and then deploy it.
       dependency_addresses.forEach(function(lib) {
+
+        if(self.libraries) {
+          var preDeployedLib = self.libraries[lib.name];
+          if(preDeployedLib && preDeployedLib.dependencies.indexOf(contract_name) !== -1) {
+            if (config.argv.quietDeploy == null) {
+              console.log('Pre-deployed library: ', preDeployedLib.name);
+            }
+            lib = preDeployedLib;
+          }
+        }
+
         if (config.argv.quietDeploy == null) {
           console.log("Linking Library: " + lib.name + " to contract: " + contract_name + " at address: " + lib.address);
         }
@@ -465,7 +497,6 @@ var Contracts = {
       compile == true;
     }
 
-    compile = true;
     async.series([
       function(c) {
         self.get_account(config, c);
@@ -485,9 +516,6 @@ var Contracts = {
           c();
         }
       },
-      function(c) {
-        self.write_contracts(config, "built contract files", c);
-      },
       //############## Deploy libraries from a list
       function(c) {
         Pudding.setWeb3(config.web3);
@@ -505,9 +533,7 @@ var Contracts = {
         // capture their addresses and use them to deploy the contracts that depend on them
         for(var i = 0; i < dependsOrdering.length; i++) {
           contract_name = dependsOrdering[i];
-          console.log('Deploy contract name: ', contract_name);
           var contract_class = config.contracts.classes[contract_name];
-
           if (contract_class == null) {
             c(new DeployError("Could not find contract '" + contract_name + "' for deployment. Check truffle.js."));
             return;
@@ -531,7 +557,6 @@ var Contracts = {
             // NOTE: since this loop is traversing in post-order, we can be assured that this list
             // will contain ALL of the dependencies of this contract
             var depends_promises = dependencies.map(dependsGraph.node, dependsGraph);
-
             // Wait for all the dependencies to be committed and then do the linking step
             deploy_promise = Promise.all(depends_promises).then(
               self.link_dependencies(config, contract_name)
@@ -550,6 +575,7 @@ var Contracts = {
           });
           c();
         }).catch(function(err) {
+          console.log(err);
           c(new DeployError(err.message, contract_name));
         });
       },
@@ -582,7 +608,6 @@ var Contracts = {
     var destination = config.contracts.build_directory;
 
     description = description || "contracts";
-
     mkdirp(destination, function(err, result) {
       if (err != null) {
         callback(err);
@@ -595,7 +620,6 @@ var Contracts = {
       }
 
       PuddingGenerator.save(config.contracts.classes, destination, {removeExisting: true});
-
       callback();
     });
   }

--- a/lib/contracts.js
+++ b/lib/contracts.js
@@ -219,11 +219,11 @@ var Contracts = {
    * @param  {object}     config      the configuration parameters object
    * @param  {function}   callback    callback to be called when the process is over
    */
-  deployLibraries: function(config, callback) {
+  deployLibraries: function(config, callback, postpone) {
 
     var self = this;
     self.libraries = [];
-    if(config.app.resolved.libraries.length === 0) return;
+    if(config.app.resolved.libraries.length === 0) return callback();
 
     Pudding.setWeb3(config.web3);
     var promises = [];
@@ -292,11 +292,13 @@ var Contracts = {
     var libraryBinAddress = library.address.replace("0x", "");
     var regex = new RegExp("__" + library.name + "_*", "g");
     var usingLibrary = regex.test(contract.binary);
-
     if(usingLibrary) {
       config.contracts.classes[contractName].binary = contract.binary.replace(regex, libraryBinAddress);
     } else {
-      config.contracts.classes[contractName].binary = contract.unlinked_binary.replace(regex, libraryBinAddress);
+      var confirmLibraryUsage = regex.test(contract.unlinked_binary);
+      if(confirmLibraryUsage) {
+        config.contracts.classes[contractName].binary = contract.unlinked_binary.replace(regex, libraryBinAddress);
+      }
     }
   },
   //############## Deploy libraries from a list
@@ -476,9 +478,17 @@ var Contracts = {
           console.log("Linking Library: " + lib.name + " to contract: " + contract_name + " at address: " + lib.address);
         }
 
-        var bin_address = lib.address.replace("0x", "");
-        var re = new RegExp("__" + lib.name + "_*", "g");
-        contract.binary = contract.unlinked_binary.replace(re, bin_address);
+        var libraryBinAddress = lib.address.replace("0x", "");
+        var regex = new RegExp("__" + lib.name + "_*", "g");
+        var usingLibrary = regex.test(contract.binary);
+        if(usingLibrary) {
+          contract.binary = contract.binary.replace(regex, libraryBinAddress);
+        } else {
+          var confirmLibraryUsage = regex.test(contract.unlinked_binary);
+          if(confirmLibraryUsage) {
+            contract.binary = contract.unlinked_binary.replace(regex, libraryBinAddress);
+          }
+        }
       });
 
       return self.createContractAndWait(config, contract_name);
@@ -510,11 +520,7 @@ var Contracts = {
       },
       //############## Deploy libraries from a list
       function(c) {
-        if(compile && config.app.resolved.libraries && config.app.resolved.libraries.length > 0) {
-          self.deployLibraries(config, c);
-        } else {
-          c();
-        }
+        self.deployLibraries(config, c);
       },
       //############## Deploy libraries from a list
       function(c) {
@@ -575,7 +581,6 @@ var Contracts = {
           });
           c();
         }).catch(function(err) {
-          console.log(err);
           c(new DeployError(err.message, contract_name));
         });
       },


### PR DESCRIPTION
If we have a contract that uses more than 1 library, the "link" from the first libraries are overwritten by the last ones