### PR TITLE
Fix #276 : Use Example.deployed() to retrieve deployed contract in tests

### DIFF
--- a/templates/example.js
+++ b/templates/example.js
@@ -1,6 +1,6 @@
 contract('Example', function(accounts) {
   it("should assert true", function(done) {
-    var example = Example.at(Example.deployed_address);
+    var example = Example.deployed();
     assert.isTrue(true);
     done();
   });


### PR DESCRIPTION
Fixes #276 
Retrieving the deployed contract this way does not result in an error.