### PR TITLE
Support --network argument for `truffle test`

### DIFF
--- a/lib/tasks.js
+++ b/lib/tasks.js
@@ -157,7 +157,9 @@ createTask('exec', "Execute a JS file within truffle environment", function(opti
 // More to come.
 createTask('test', "Run tests", function(options, done) {
   var config = Truffle.config.detect(options);
-  config.network = "test";
+  if (config.network === "default") { 
+    config.network = "test";
+  }
 
   var files = [];
 


### PR DESCRIPTION
I have a `truffle.js` that looks like this:

```
module.exports = {
  rpc: {
    host: 'localhost',
    gasPrice: 20e9,
  },
  mocha: {
    reporter: 'spec',
  },
  networks: {
    "coverage":{
        network_id:1919191,
        port:  8546,
    }
  }
};
```

And while it works for `truffle migrate --network coverage`, it failed to work for `truffle test --network coverage`. I feel like if the user is specifying the network explicitly, that should be respected. Have I overlooked a knock-on consequence o not running the 'test' command on the 'test' network?

This PR leaves the current functionality for just the `truffle test` command i.e. network is set to 'test'.
