### PR TITLE
Fix error handling in truffle console

### DIFF
--- a/lib/repl.js
+++ b/lib/repl.js
@@ -22,7 +22,10 @@ TruffleInterpreter.prototype.start = function() {
   web3.setProvider(options.provider);
 
   this.provision(function(err) {
-    if (err) return done(err);
+    if (err) {
+      console.log(err.stack);
+      process.exit(1);
+    }
 
     var prefix = "truffle(default)> ";
 


### PR DESCRIPTION
`done` is not defined in this context. It's probably a leftover from a previous refactor.

These kinds of errors can be trivially recognized by a linter. If you are interested, I can configure [eslint](http://eslint.org/) for this project in another pull request.
