### PR TITLE
added bytecode and abi generation to compiling contracts

### DIFF
--- a/lib/contracts.js
+++ b/lib/contracts.js
@@ -123,7 +123,18 @@ var Contracts = {
       if (options.quiet != true && options.quietWrite != true) {
         logger.log("Writing artifacts to ." + path.sep + path.relative(process.cwd(), options.contracts_build_directory));
       }
-
+      Object.keys(contracts).forEach((key) =>{
+        fs.writeFile(options.contracts_build_directory+'/'+key+'.abi', contracts[key].interface, (err)=>{
+          if(err){
+            console.log(err);
+          }
+        });
+        fs.writeFile(options.contracts_build_directory+'/'+key+'.bin', contracts[key].bytecode, (err)=>{
+          if(err){
+            console.log(err);
+          }
+        });
+      });
       Pudding.saveAll(contracts, options.contracts_build_directory, options).then(function() {
         callback(null, contracts);
       }).catch(callback);


### PR DESCRIPTION
I find it very helpful for the abi and the bytecode to be generated as well as the javascript functions on contract compilation.  This PR generates the abi and bytecode every time the contract is compiled.