### PR TITLE
Update link to current documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ $ npm install -g truffle
 
 ### Documentation
 
-Please see the [Official Truffle Documentation](http://truffle.readthedocs.org/en/latest/) for guides, tips, and examples.
+Please see the [Official Truffle Documentation](http://truffleframework.com/docs/) for guides, tips, and examples.
 
 ### Contributing
 


### PR DESCRIPTION
It appears that the **Read the Docs** documentation is deprecated in favour of those found on truffleframework.com, so this just updates the URL in the README