### PR TITLE
Update Official Truffle Documentation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ $ npm install -g truffle
 
 ### Documentation
 
-Please see the [Official Truffle Documentation](http://truffle.readthedocs.org/en/latest/) for guides, tips, and examples.
+Please see the [Official Truffle Documentation](http://truffleframework.com/docs/) for guides, tips, and examples.
 
 ### Contributing
 


### PR DESCRIPTION
According to [truffleframework.com](https://truffleframework.com) the
latest docs are at [truffleframework.com/docs](http://truffleframework.com/docs/)
so this patches README.md.