### PR TITLE
Add the packaging metadata to build the truffle snap

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,0 +1,21 @@
+name: truffle
+version: master
+summary: A development framework for Ethereum
+description: |
+  Truffle is the most popular development framework for Ethereum with a mission
+  to make your life a whole lot easier.
+
+grade: devel
+confinement: strict
+
+apps:
+  truffle:
+    command: truffle
+    plugs: [home, network, network-bind]
+
+parts:
+  truffle:
+    source: .
+    plugin: nodejs
+    node-engine: '5.12.0'
+    build-packages: [g++, make, python]


### PR DESCRIPTION
This is a package for the secure installation of apps that works in most Linux distributions.
Landing it upstream will enable builds that then can be distributed to many users through the Ubuntu store.