### PR TITLE
Fix config export to truffle-config instead of ./lib/config.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ module.exports = {
   build: require("./lib/build"),
   create: require("./lib/create"),
   compiler: require("truffle-compile"),
-  config: require("./lib/config"),
+  config: require("truffle-config"),
   console: require("./lib/repl"),
   contracts: require("./lib/contracts"),
   require: require("truffle-require"),


### PR DESCRIPTION
Just some clean up: this was just forgotten behind as lib/config.js was removed.
