### PR TITLE
Fix compile command failure

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -112,8 +112,9 @@ module.exports = {
       for (var i = 0; i < filenames.length; i++) {
         var filename = filenames[i];
         var expected_contract = path.basename(filename, ".sol");
+        var contract_key = filename + ":" + expected_contract;
 
-        if (result.contracts[expected_contract] == null) {
+        if (result.contracts[contract_key] == null) {
           return callback(new CompileError("Could not find expected contract or library in '" + filename + "': contract or library '" + expected_contract + "' not found."));
         }
       }


### PR DESCRIPTION
After trying Truffle's compile command on the init supplied contracts, I received the following error:

```
Could not find expected contract or library in 'ConvertLib.sol': contract or library 'ConvertLib' not found.
```

Upon digging deeper, it looks like a breaking change was introduced to `solc` 6 hours ago in their latest version update to  v0.4.9 (https://github.com/ethereum/solc-js/pull/82). It changes the top-level keys from being contract filenames, to keys of the form `filename.sol:filename`.

I also notice that this change also breaks Truffle-artifactor (https://github.com/trufflesuite/truffle-artifactor). Given this fact, perhaps it makes more sense to simply fix the version to solc 0.4.8 for now.

Hope this helps!